### PR TITLE
La til funksjonalitet for å stoppe oppdatering av infotrygd for sykme…

### DIFF
--- a/src/main/kotlin/no/nav/syfo/services/UpdateInfotrygdService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/UpdateInfotrygdService.kt
@@ -602,7 +602,7 @@ class UpdateInfotrygdService {
         validationResult: ValidationResult
     ): Boolean {
 
-        val partiallySickLeaveRule = validationResult.ruleHits.isNotEmpty() && validationResult.ruleHits.any {
+        val delvisOverlappendeSykmeldingRule = validationResult.ruleHits.isNotEmpty() && validationResult.ruleHits.any {
             (it.ruleName == ValidationRuleChain.PARTIALLY_COINCIDENT_SICK_LEAVE_PERIOD_WITH_PREVIOUSLY_REGISTERED_SICK_LEAVE.name)
         } && receivedSykmelding.sykmelding.perioder.sortedPeriodeFOMDate().lastOrNull() != null &&
             receivedSykmelding.sykmelding.perioder.sortedPeriodeTOMDate().lastOrNull() != null &&
@@ -611,10 +611,9 @@ class UpdateInfotrygdService {
         val merknadRule = receivedSykmelding.merknader?.any {
             it.type == "UGYLDIG_TILBAKEDATERING" ||
                 it.type == "TILBAKEDATERING_KREVER_FLERE_OPPLYSNINGER"
-        }
-            ?: false
+        }?: false
 
-        return partiallySickLeaveRule || merknadRule
+        return delvisOverlappendeSykmeldingRule || merknadRule
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/services/UpdateInfotrygdService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/UpdateInfotrygdService.kt
@@ -600,10 +600,22 @@ class UpdateInfotrygdService {
     fun skalIkkeOppdatereInfotrygd(
         receivedSykmelding: ReceivedSykmelding,
         validationResult: ValidationResult
-    ): Boolean =
-        validationResult.ruleHits.isNotEmpty() && validationResult.ruleHits.any {
+    ): Boolean {
+
+        val partiallySickLeaveRule = validationResult.ruleHits.isNotEmpty() && validationResult.ruleHits.any {
             (it.ruleName == ValidationRuleChain.PARTIALLY_COINCIDENT_SICK_LEAVE_PERIOD_WITH_PREVIOUSLY_REGISTERED_SICK_LEAVE.name)
-        } && receivedSykmelding.sykmelding.perioder.sortedPeriodeFOMDate().lastOrNull() != null && receivedSykmelding.sykmelding.perioder.sortedPeriodeTOMDate().lastOrNull() != null && (receivedSykmelding.sykmelding.perioder.sortedPeriodeFOMDate().last()..receivedSykmelding.sykmelding.perioder.sortedPeriodeTOMDate().last()).daysBetween() <= 3
+        } && receivedSykmelding.sykmelding.perioder.sortedPeriodeFOMDate().lastOrNull() != null &&
+            receivedSykmelding.sykmelding.perioder.sortedPeriodeTOMDate().lastOrNull() != null &&
+            (receivedSykmelding.sykmelding.perioder.sortedPeriodeFOMDate().last()..receivedSykmelding.sykmelding.perioder.sortedPeriodeTOMDate().last()).daysBetween() <= 3
+
+        val merknadRule = receivedSykmelding.merknader?.any {
+            it.type == "UGYLDIG_TILBAKEDATERING" ||
+                it.type == "TILBAKEDATERING_KREVER_FLERE_OPPLYSNINGER"
+        }
+            ?: false
+
+        return partiallySickLeaveRule || merknadRule
+    }
 }
 
 @KtorExperimentalAPI

--- a/src/test/kotlin/no/nav/syfo/SkalIkkeOppdatereInfotrygdSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/SkalIkkeOppdatereInfotrygdSpek.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo
 
 import io.ktor.util.KtorExperimentalAPI
+import no.nav.syfo.model.Merknad
 import no.nav.syfo.model.RuleInfo
 import no.nav.syfo.model.Status
 import no.nav.syfo.model.ValidationResult
@@ -116,6 +117,75 @@ object SkalIkkeOppdatereInfotrygdSpek : Spek({
                         )
                     )
                 )
+            )
+
+            updateInfotrygdService.skalIkkeOppdatereInfotrygd(receivedSykmelding, validationResult) shouldBeEqualTo false
+        }
+
+        it("Skal ikke oppdatere infotrygd fordi sykmeldingen har merknad UGYLDIG_TILBAKEDATERING") {
+
+            val validationResult = ValidationResult(
+                status = Status.OK,
+                ruleHits = emptyList()
+            )
+
+            val receivedSykmelding = receivedSykmelding(
+                "1",
+                generateSykmelding(
+                    perioder = listOf(
+                        generatePeriode(
+                            fom = LocalDate.of(2019, 1, 1),
+                            tom = LocalDate.of(2019, 1, 5)
+                        )
+                    )
+                ),
+                merknader = listOf(Merknad(type = "UGYLDIG_TILBAKEDATERING", beskrivelse = "Litt av en beskrivelse"))
+            )
+
+            updateInfotrygdService.skalIkkeOppdatereInfotrygd(receivedSykmelding, validationResult) shouldBeEqualTo true
+        }
+
+        it("Skal ikke oppdatere infotrygd fordi sykmeldingen har merknad TILBAKEDATERING_KREVER_FLERE_OPPLYSNINGER") {
+
+            val validationResult = ValidationResult(
+                status = Status.OK,
+                ruleHits = emptyList()
+            )
+
+            val receivedSykmelding = receivedSykmelding(
+                "1",
+                generateSykmelding(
+                    perioder = listOf(
+                        generatePeriode(
+                            fom = LocalDate.of(2019, 1, 1),
+                            tom = LocalDate.of(2019, 1, 5)
+                        )
+                    )
+                ),
+                merknader = listOf(Merknad(type = "TILBAKEDATERING_KREVER_FLERE_OPPLYSNINGER", beskrivelse = "Litt av en beskrivelse"))
+            )
+
+            updateInfotrygdService.skalIkkeOppdatereInfotrygd(receivedSykmelding, validationResult) shouldBeEqualTo true
+        }
+
+        it("Skal oppdatere infotrygd fordi sykmeldingen har en ukjent merknad") {
+
+            val validationResult = ValidationResult(
+                status = Status.OK,
+                ruleHits = emptyList()
+            )
+
+            val receivedSykmelding = receivedSykmelding(
+                "1",
+                generateSykmelding(
+                    perioder = listOf(
+                        generatePeriode(
+                            fom = LocalDate.of(2019, 1, 1),
+                            tom = LocalDate.of(2019, 1, 5)
+                        )
+                    )
+                ),
+                merknader = listOf(Merknad(type = "Litt av en type", beskrivelse = "Litt av en beskrivelse"))
             )
 
             updateInfotrygdService.skalIkkeOppdatereInfotrygd(receivedSykmelding, validationResult) shouldBeEqualTo false

--- a/src/test/kotlin/no/nav/syfo/Testdata.kt
+++ b/src/test/kotlin/no/nav/syfo/Testdata.kt
@@ -19,6 +19,7 @@ import no.nav.syfo.model.MedisinskArsak
 import no.nav.syfo.model.MedisinskArsakType
 import no.nav.syfo.model.MedisinskVurdering
 import no.nav.syfo.model.MeldingTilNAV
+import no.nav.syfo.model.Merknad
 import no.nav.syfo.model.Periode
 import no.nav.syfo.model.Prognose
 import no.nav.syfo.model.ReceivedSykmelding
@@ -29,7 +30,11 @@ import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.random.Random
 
-fun receivedSykmelding(id: String, sykmelding: Sykmelding = generateSykmelding()) = ReceivedSykmelding(
+fun receivedSykmelding(
+    id: String,
+    sykmelding: Sykmelding = generateSykmelding(),
+    merknader: List<Merknad>? = null
+) = ReceivedSykmelding(
     sykmelding = sykmelding,
     personNrPasient = "123124",
     tlfPasient = "12314",
@@ -44,7 +49,7 @@ fun receivedSykmelding(id: String, sykmelding: Sykmelding = generateSykmelding()
     rulesetVersion = "",
     fellesformat = "",
     tssid = "",
-    merknader = null
+    merknader = merknader
 )
 
 fun generateSykmelding(


### PR DESCRIPTION
…ldinger med merknad

https://trello.com/c/KDrJvIUj/1506-infotrygd-skal-ikke-oppdateres-n%C3%A5r-tilbakedatert-sykmelding-er-avsl%C3%A5tt-eller-det-er-behov-for-mer-informasjon